### PR TITLE
Use GET to access OSRM in place of POST

### DIFF
--- a/src/loaders/osrm_wrapper.h
+++ b/src/loaders/osrm_wrapper.h
@@ -38,7 +38,7 @@ private:
   std::string build_query(const std::vector<std::pair<double, double>>& locations, 
                           std::string service, std::string extra_args = "") const{
     // Building query for osrm-routed
-    std::string query = "POST /" + service + "?";
+    std::string query = "GET /" + service + "?";
 
     // Adding locations.
     for(auto const& location: locations){


### PR DESCRIPTION
Use GET to access OSRM in place of POST, since there is nothing to POST and OSRM 4.8.1 return error on POST to /table