### PR TITLE
Minor fix to parse response of osrm v4.6.0

### DIFF
--- a/src/loaders/osrm_wrapper.h
+++ b/src/loaders/osrm_wrapper.h
@@ -135,7 +135,7 @@ public:
     assert(response.find("Bad Request") == std::string::npos);
 
     // Removing headers.
-    std::string distance_key = "{\"distance_table\":[";
+    std::string distance_key = "\"distance_table\":[";
     size_t table_start = response.find(distance_key);
     assert(table_start != std::string::npos);
 


### PR DESCRIPTION
The new request result for distance_table is not contained into a dict.

This change is backward compatible with the previous OSRM version.

Signed-off-by: Francis Giraldeau <francis.giraldeau@gmail.com>